### PR TITLE
Fixed AppBar elements overflow problem

### DIFF
--- a/step-greener-app/lib/app_bar.dart
+++ b/step-greener-app/lib/app_bar.dart
@@ -15,35 +15,51 @@ class StepGreenerAppBar extends StatelessWidget implements PreferredSizeWidget {
   });
 
   @override
-  Size get preferredSize => Size.fromHeight(kToolbarHeight + 10);
+  Size get preferredSize => Size.fromHeight(kToolbarHeight);
 
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      leading: IconButton(
-        icon: Icon(menuIcon),
-        onPressed: onMenuIconPressed,
-        iconSize: 50,
+      flexibleSpace: LayoutBuilder(
+        builder: (context, constraints) {
+          double width = constraints.maxWidth;
+          return Center(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                IconButton(
+                  icon: Icon(menuIcon),
+                  onPressed: onMenuIconPressed,
+                  iconSize: 50,
+                ),
+                Row( // Place logo and App Title close together
+                  children: [
+                    Image.asset(
+                      'assets/images/right_footprint.png',
+                      width: width * 0.06
+                    ),
+                    Text("StepGreener", 
+                      style: GoogleFonts.poppins(
+                        textStyle: TextStyle(
+                          fontSize: width * 0.06,
+                          fontWeight: FontWeight.w500,
+                          color: AppColors.primaryText
+                        )
+                      ) 
+                    )
+                  ]
+                ),
+                // SizedBox(width: 10),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: PointsDisplay()
+                ),
+              ],
+            ),
+          );
+        }
       ),
-      title: Row(
-        children: [
-          Image.asset(
-            'assets/images/right_footprint.png',
-            width: 30
-          ),
-          Text("StepGreener", 
-            style: GoogleFonts.poppins(
-              textStyle: TextStyle(
-                fontSize: 35,
-                fontWeight: FontWeight.w500,
-                color: AppColors.primaryText
-              )
-            ) 
-          ),
-          SizedBox(width: 10),
-          PointsDisplay(),
-        ],
-      ),
+      title: null,
       backgroundColor: AppColors.primaryBackground,
       shape: Border(
         bottom: BorderSide(
@@ -54,71 +70,3 @@ class StepGreenerAppBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 }
-
-// import 'package:flutter/material.dart';
-// import 'package:google_fonts/google_fonts.dart';
-// import 'package:google_maps_in_flutter/app_colors.dart';
-
-// class StepGreenerAppBar extends StatefulWidget implements PreferredSizeWidget {
-//   final GlobalKey<ScaffoldState> scaffoldkey;
-//   final GlobalKey<StepGreenerAppBarState> appBarKey;
-
-//   const StepGreenerAppBar({super.key, required this.scaffoldkey, required this.appBarKey});
-
-//   @override
-//   State<StepGreenerAppBar> createState() => StepGreenerAppBarState();
-  
-//   @override
-//   Size get preferredSize => Size.fromHeight(kToolbarHeight + 10); // Add 10 for padding below title: StepGreener
-// }
-
-// class StepGreenerAppBarState extends State<StepGreenerAppBar> {
-//   bool isMenuOpen = false;
-
-//   void toggleMenu() {
-//     setState( () {
-//       isMenuOpen = !isMenuOpen;
-//       if ( isMenuOpen ) {
-//         widget.scaffoldkey.currentState?.openDrawer();
-//       } else {
-//         // widget.scaffoldkey.currentState?.openEndDrawer();
-//         widget.scaffoldkey.currentState?.closeDrawer();
-//       }
-//     } );
-//   }
-//   void changeIconState() {
-
-//   }
-
-//   @override
-//   Widget build(BuildContext context) {
-//     return AppBar(
-//       key: widget.appBarKey,
-//       leading: IconButton(
-//         icon: Icon( isMenuOpen ? Icons.close : Icons.menu ),
-//         onPressed: toggleMenu,
-//         iconSize: 50,
-//       ),
-//       title: Row(
-//         children: [
-//           Image.asset(
-//             'assets/images/right_footprint.png',
-//             width: 30
-//           ),
-//           Text("StepGreener", 
-//             style: GoogleFonts.poppins(
-//               textStyle: TextStyle(
-//                 fontSize: 35,
-//                 fontWeight: FontWeight.w500,
-//                 color: AppColors.primaryText
-//               )
-//             ) 
-//           ),
-//         ],
-//       ),
-//       backgroundColor: AppColors.primaryBackground,
-//       elevation: 2,
-//     );
-      
-//   }
-// }

--- a/step-greener-app/lib/main.dart
+++ b/step-greener-app/lib/main.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 // import 'package:google_maps_flutter/google_maps_flutter.dart';
-// import 'package:google_maps_in_flutter/login_page.dart';
+import 'package:google_maps_in_flutter/login_page.dart';
 import 'package:google_maps_in_flutter/page_template.dart';
+import 'package:google_maps_in_flutter/splash_screen.dart';
 
 // helloooooo dis is our App :3
 StepGreenerApp stepGreenerApp = StepGreenerApp();

--- a/step-greener-app/lib/menu_drawer.dart
+++ b/step-greener-app/lib/menu_drawer.dart
@@ -27,7 +27,7 @@ class MenuDrawer extends StatelessWidget {
           child: ListView(
             children: [
               SizedBox(
-                height: 80, 
+                height: 70, 
                 child: DrawerHeader(
                   decoration: BoxDecoration(
                     color: AppColors.primaryBackground,
@@ -37,7 +37,7 @@ class MenuDrawer extends StatelessWidget {
                     'Menu',
                     style: TextStyle(
                       color: AppColors.primaryText,
-                      fontSize: 30,
+                      fontSize: 20,
                     ),
                   ),
                 ),

--- a/step-greener-app/lib/points_display.dart
+++ b/step-greener-app/lib/points_display.dart
@@ -11,8 +11,8 @@ class PointsDisplay extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
             padding: EdgeInsets.all(5), // Padding inside the container
-            height: 40,
-            width: 90,
+            height: 35,
+            width: 85,
             decoration: BoxDecoration(
               border: Border.all(color: AppColors.primaryBorder, width: 3), // Border around the container
               borderRadius: BorderRadius.circular(12),
@@ -24,7 +24,7 @@ class PointsDisplay extends StatelessWidget {
                   child: Text(
                     '$totalPoints', // Displaying the total points
                     style: TextStyle(
-                      fontSize: 16,
+                      fontSize: 14,
                       fontWeight: FontWeight.bold,
                       color: Colors.black,
                     ),


### PR DESCRIPTION
use AppBar flex space instead of title to display elements to adjust flexibly to width of phone